### PR TITLE
feat(cmd): add source cmd

### DIFF
--- a/cmd/source/source.go
+++ b/cmd/source/source.go
@@ -20,45 +20,39 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-// Package cmd defines root command and is the entry point for this tool.
-package cmd
+// Package source defines the `source` command.
+package source
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/peter-bread/gamon3/cmd/hook"
-	"github.com/peter-bread/gamon3/cmd/run"
-	"github.com/peter-bread/gamon3/cmd/source"
+	"github.com/peter-bread/gamon3/internal/gamon3cmd"
+
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "gamon3",
-	Short: "Automatic GH CLI account switching on cd",
-	Long: `Automatic GH CLI account switching on cd.
+// SourceCmd represents the run command.
+var SourceCmd = &cobra.Command{
+	Use:   "source",
+	Short: "Prints source of current acount",
+	Long: `Prints source of current acount.
 
-Gamon3 is a tool that enables automatic GH CLI account switching based on a
-context, specifically 'pwd'. It does this by hooking into the 'cd' command.
+Prints which GH CLI account should be active and which method was used
+to resolve this.
+
+There are three methods used to determine which account should be used:
+1. $GAMON3_ACCOUNT environment variable
+2. Checking '.gamon.yaml' or '.gamon.yml' local config file
+3. Main user config file 'config.yaml'
 `,
-}
+	Run: func(cmd *cobra.Command, args []string) {
+		_, _, source, err := gamon3cmd.Resolve()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
-}
-
-func SetVersion(version, commit, date string) {
-	// TODO: Use `commit` and `date` in version output (MAYBE).
-	rootCmd.Version = version
-}
-
-func init() {
-	rootCmd.AddCommand(run.RunCmd)
-	rootCmd.AddCommand(hook.HookCmd)
-	rootCmd.AddCommand(source.SourceCmd)
+		fmt.Println(source)
+	},
 }

--- a/internal/gamon3cmd/resolve.go
+++ b/internal/gamon3cmd/resolve.go
@@ -26,9 +26,11 @@ func Resolve() (currentAccount string, account string, source string, err error)
 	// Check $GAMON3_ACCOUNT.
 	// IMPORTANT: $GAMON3_ACCOUNT *must* be exported.
 
-	if account, found := os.LookupEnv("GAMON3_ACCOUNT"); found {
+	gamon3EnvVar := "GAMON3_ACCOUNT"
+
+	if account, found := os.LookupEnv(gamon3EnvVar); found {
 		if slices.Contains(users, account) {
-			return currentAccount, account, "environment variable", nil
+			return currentAccount, account, output("Environment variable", gamon3EnvVar, account), nil
 		} else {
 			fmt.Printf("[GAMON3 WARN] '%s' is not a valid account\n", account)
 			fmt.Println("[GAMON3 INFO] Falling back to local config file")
@@ -46,7 +48,8 @@ func Resolve() (currentAccount string, account string, source string, err error)
 			fmt.Printf("[GAMON3 WARN] '%s' is not a valid local config file\n", localConfigPath)
 			fmt.Println("[GAMON3 INFO] Falling back to main config file")
 		} else {
-			return currentAccount, localConfig.Account, "local config", nil
+			account = localConfig.Account
+			return currentAccount, account, output("Local config file", localConfigPath, account), nil
 		}
 	}
 
@@ -66,5 +69,9 @@ func Resolve() (currentAccount string, account string, source string, err error)
 
 	pwd := os.Getenv("PWD")
 	account = config.GetAccount(pwd)
-	return currentAccount, account, "main config", nil
+	return currentAccount, account, output("Config file", configPath, account), nil
+}
+
+func output(kind, value, account string) string {
+	return fmt.Sprintf("%s: %s\nAccount: %s", kind, value, account)
 }

--- a/internal/gamon3cmd/resolve.go
+++ b/internal/gamon3cmd/resolve.go
@@ -1,0 +1,70 @@
+package gamon3cmd
+
+import (
+	"fmt"
+	"os"
+	"slices"
+)
+
+func Resolve() (currentAccount string, account string, source string, err error) {
+	var ghHosts GHHosts
+
+	ghHostsPath, err := GetGHHostsPath()
+	if err != nil {
+		// TODO: Should I still return the original error?
+		return "", "", "", fmt.Errorf("%s", "[GAMON3 ERROR] Failed to get path for GH CLI 'hosts.yml'")
+	}
+
+	if err := ghHosts.Load(ghHostsPath); err != nil {
+		// TODO: Should I still return the original error?
+		return "", "", "", fmt.Errorf("%s", "[GAMON3 ERROR] Failed to load GH CLI 'hosts.yml'")
+	}
+
+	currentAccount = ghHosts.GetCurrentUser()
+	users := ghHosts.GetAllUsers()
+
+	// Check $GAMON3_ACCOUNT.
+	// IMPORTANT: $GAMON3_ACCOUNT *must* be exported.
+
+	if account, found := os.LookupEnv("GAMON3_ACCOUNT"); found {
+		if slices.Contains(users, account) {
+			return currentAccount, account, "environment variable", nil
+		} else {
+			fmt.Printf("[GAMON3 WARN] '%s' is not a valid account\n", account)
+			fmt.Println("[GAMON3 INFO] Falling back to local config file")
+		}
+	}
+
+	// Walk up filetree looking for a local '.gamon3.yaml' file.
+	// It should also stop walking at the $HOME directory, at which point it
+	// falls back to 'config.yaml'.
+
+	var localConfig LocalConfig
+
+	if localConfigPath, err := GetLocalConfigPath(); err == nil {
+		if err := localConfig.Load(localConfigPath, users); err != nil {
+			fmt.Printf("[GAMON3 WARN] '%s' is not a valid local config file\n", localConfigPath)
+			fmt.Println("[GAMON3 INFO] Falling back to main config file")
+		} else {
+			return currentAccount, localConfig.Account, "local config", nil
+		}
+	}
+
+	// Check main 'config.yaml' file.
+
+	var config Config
+
+	configPath, err := GetConfigPath()
+	if err != nil {
+		return currentAccount, "", "", nil
+	}
+
+	if err := config.Load(configPath, users); err != nil {
+		errorMsg := fmt.Sprintf("[GAMON3 ERROR] '%s' is not a valid local config file\n", configPath)
+		return currentAccount, "", "", fmt.Errorf("%s", errorMsg)
+	}
+
+	pwd := os.Getenv("PWD")
+	account = config.GetAccount(pwd)
+	return currentAccount, account, "main config", nil
+}


### PR DESCRIPTION
Fixes #17.

This PR adds a new command, `gamon3 source`. This command prints the method that was used to resolve which GitHub account should be used in the current directory.

Examples:

```
$ gamon3 source
Config file: /Users/petersheehan/.config/gamon3/config.yaml
Account: peter-bread
```

```
$ gamon3 source
Local config file: /Users/petersheehan/Developer/peter-bread/gamon3/.gamon.yaml
Account: peter-bread
```

```
$ gamon3 source
Environment variable: GAMON3_ACCOUNT
Account: peter-bread
```

This is mainly to make debugging easier. If you haven't used a system for a while, it's easy to forget about a rogue `.gamon.yaml` and then wonder why it's not behaving how you would expect.

This is very similar to `gamon3 run`, but instead of switching accounts it prints information. So this PR is essentially decoupling the account resolving from the account switching. There is a single function which both commands use, they just do different things with the results.

> Maybe add a verbose option to also print the value of the variable or the contents of the config file.

I decided against adding a verbose option. Printing the source and the account seems like enough.